### PR TITLE
To fix the problem of provider_version slot

### DIFF
--- a/R/AnnotationGenome.R
+++ b/R/AnnotationGenome.R
@@ -41,7 +41,7 @@ createGenomeAnnotation <- function(
 
     ##################
     message("Getting blacklist..")
-    blacklist <- .getBlacklist(genome = bsg@provider_version)
+    blacklist <- .getBlacklist(genome = bsg@metadata$genome)
 
   }else{
 

--- a/R/AnnotationPeaks.R
+++ b/R/AnnotationPeaks.R
@@ -606,7 +606,7 @@ addArchRAnnotations <- function(
     }
   }
 
-  genome <- tolower(validBSgenome(getGenome(ArchRProj))@provider_version)
+  genome <- tolower(validBSgenome(getGenome(ArchRProj))@metadata$genome)
 
   annoPath <- file.path(find.package("ArchR", NULL, quiet = TRUE), "data", "Annotations")
   dir.create(annoPath, showWarnings = FALSE)


### PR DESCRIPTION
The provider_version slot was replaced with the genome argument of metadata slot in the new version of BSgenome.