### PR TITLE
Fixed an issue in plotTrajectory with 3D embeddings.

### DIFF
--- a/R/Trajectory.R
+++ b/R/Trajectory.R
@@ -734,6 +734,10 @@ plotTrajectory <- function(
   # Get Embedding
   ##############################
   df <- getEmbedding(ArchRProj, embedding = embedding, returnDF = TRUE)
+  if (length(colnames(df)) > 2){
+    .logMessage("Greater than two dimensions in embedding, only keeping the first two.", logFile = logFile)
+    df <- df[,1:2]
+  }
   .logThis(df, "embedding", logFile = logFile)
   dfT <- cbind(df, dfT[rownames(df),])
   colnames(dfT) <- c("x", "y", "PseudoTime")


### PR DESCRIPTION
When working with a 3D UMAP embedding (n_components = 3), I discovered that this broke the plotting of the Inferred Arrow on a pseudotime trajectoryPlot. To fix this issue, I remove any dimensions after the first two when retrieving the embedding for this function. 

Error before
`plotTrajectory(projNC, trajectory = "Mesenchyme", colorBy = "cellColData", name = "Mesenchyme", plotAs = "points")`

```
5: stop("names do not match previous names")
4: match.names(clabs, names(xi))
3: rbind(deparse.level, ...)
2: rbind(dfArrow, dfT[nrow(dfT), , drop = FALSE])
1: plotTrajectory(projNC, trajectory = "Mesenchyme", colorBy = "cellColData", 
       name = "Mesenchyme", plotAs = "points")
```
With the proposed changes

```
ArchR logging to : ArchRLogs/ArchR-plotTrajectory-d0a2678ec192-Date-2021-03-23_Time-17-01-28.log
If there is an issue, please report to github with logFile!
Greater than 2 dimensions in embedding, only keeping the first two.
Plotting
Plotting Trajectory
Adding Inferred Arrow Trajectory to Plot
ArchR logging successful to : ArchRLogs/ArchR-plotTrajectory-d0a2678ec192-Date-2021-03-23_Time-17-01-28.log
```