### PR TITLE
Dev custom genome

### DIFF
--- a/R/AnnotationPeaks.R
+++ b/R/AnnotationPeaks.R
@@ -429,7 +429,6 @@ addMotifAnnotations <- function(
   # Get BSgenome Information!
   #############################################################
   genome <- ArchRProj@genomeAnnotation$genome
-  .requirePackage(genome)
   BSgenome <- eval(parse(text = genome))
   BSgenome <- validBSgenome(BSgenome)
 

--- a/R/Footprinting.R
+++ b/R/Footprinting.R
@@ -68,7 +68,6 @@ getFootprints <- function(
   }
 
   genome <- getGenome(ArchRProj)
-  .requirePackage(genome)
   .requirePackage("Biostrings", source = "bioc")
   BSgenome <- eval(parse(text = genome))
   BSgenome <- validBSgenome(BSgenome)

--- a/R/GroupCoverages.R
+++ b/R/GroupCoverages.R
@@ -585,7 +585,6 @@ addGroupCoverages <- function(
 
   .logThis(append(args, mget(names(formals()),sys.frame(sys.nframe()))), "kmerBias-Parameters", logFile = logFile)
   
-  .requirePackage(genome)
   .requirePackage("Biostrings", source = "bioc")
   BSgenome <- eval(parse(text = genome))
   BSgenome <- validBSgenome(BSgenome)

--- a/R/ProjectMethods.R
+++ b/R/ProjectMethods.R
@@ -390,7 +390,6 @@ addPeakSet <- function(
 
     #Get NucleoTide Content
     peakSet <- tryCatch({
-      .requirePackage(genomeAnnotation$genome)
       .requirePackage("Biostrings",source="bioc")
       BSgenome <- eval(parse(text = genomeAnnotation$genome))
       BSgenome <- validBSgenome(BSgenome)

--- a/R/ReproduciblePeakSet.R
+++ b/R/ReproduciblePeakSet.R
@@ -213,7 +213,6 @@ addReproduciblePeakSet <- function(
 		#####################################################
 		# BSgenome for Add Nucleotide Frequencies!
 		#####################################################
-		.requirePackage(genomeAnnotation$genome)
 		.requirePackage("Biostrings",source="bioc")
 		BSgenome <- eval(parse(text = genomeAnnotation$genome))
 		BSgenome <- validBSgenome(BSgenome)


### PR DESCRIPTION
remove `.requirePackage(genome)` calls from various functions. When users create a custom genome from scratch, they do not have a package installed that matches their genome so this always fails. However, `validBSgenome()` covers this requirement already so the `.requirePackage(genome)` calls shouldnt be needed.