### PR TITLE
bugfix for tabix dt column names

### DIFF
--- a/R/CreateArrow.R
+++ b/R/CreateArrow.R
@@ -1260,9 +1260,9 @@ createArrowFiles <- function(
       }
 
       #No NAs
-      dt <- dt[!is.na(dt$RG), , drop=FALSE] 
-      dt <- dt[!is.na(dt$start), , drop=FALSE]
-      dt <- dt[!is.na(dt$end), , drop=FALSE]
+      dt <- dt[!is.na(dt$V2), , drop=FALSE] 
+      dt <- dt[!is.na(dt$V3), , drop=FALSE]
+      dt <- dt[!is.na(dt$V4), , drop=FALSE]
 
       #Care for Break Points
       dt <- dt[dt$V2 >= start(tileChromSizes[x]),]

--- a/R/CreateArrow.R
+++ b/R/CreateArrow.R
@@ -1153,11 +1153,11 @@ createArrowFiles <- function(
     }
   }, error = function(x){
     tryCatch({
-      if(getArchRVerbose()) 
-       ("Attempting to index ", file," as bam...")
+      if(getArchRVerbose()) message("Attempting to index ", file," as bam...")
       indexBam(file)
       TRUE
     }, error = function(y){
+      message("Indexing of BAM file failed for ",file,".")
       FALSE
     })
   })

--- a/R/CreateArrow.R
+++ b/R/CreateArrow.R
@@ -1137,6 +1137,7 @@ createArrowFiles <- function(
       indexTabix(file, format = "bed")
       TRUE
     }, error = function(y){
+      message("Tabix indexing failed for ", file,". Note that ArchR requires bgzipped fragment files which is different from gzip. See samtools bgzip!")
       FALSE
     })
   })
@@ -1152,7 +1153,8 @@ createArrowFiles <- function(
     }
   }, error = function(x){
     tryCatch({
-      if(getArchRVerbose()) message("Attempting to index ", file," as bam...")
+      if(getArchRVerbose()) 
+       ("Attempting to index ", file," as bam...")
       indexBam(file)
       TRUE
     }, error = function(y){


### PR DESCRIPTION
I've tested this on my end and this is a high-priority fix that needs to be corrected. arrow file creation fails on release_1.0.2 without this patch.

It looks like the code that applied to bam input was copied to also apply to fragment input and the column names might not have been correct.

The problem was introduced in this commit: https://github.com/GreenleafLab/ArchR/commit/fe4810162e293d98101c277f4cb5ff434280829f