### PR TITLE
Marker features change

### DIFF
--- a/R/HiddenUtils.R
+++ b/R/HiddenUtils.R
@@ -108,6 +108,32 @@
   return(z)
 }
 
+.computeClostestCellsList <- function(
+    data = NULL,
+    query = NULL,
+    k = 50,
+    ...
+){
+  .validInput(input = data, name = "data", valid = c("dataframe", "matrix"))
+  .validInput(input = query, name = "query", valid = c("dataframe", "matrix"))
+  .validInput(input = k, name = "k", valid = c("integer"))
+  .requirePackage("nabor", source = "cran")
+  
+  nn1 = nabor::knn(data = data, query = query, k = k, ...)
+  dists = nn1$nn.dists
+  indxs = nn1$nn.idx
+  data = c()
+  elements_len = dim(indxs)[2]
+  for (i in 1:dim(indxs)[1]){
+    new_part = cbind(rep(i, elements_len), indxs[i,], dists[i,])
+    data = rbind(data, new_part)
+  }
+  pairs_dist_df = as.data.frame(data)
+  colnames(pairs_dist_df) = c("Cells", "Bgd", "Dist")
+  pairs_dist_df = pairs_dist_df[order(pairs_dist_df$Dist),]
+  pairs_dist_df
+}
+
 .computeROC <- function(labels = NULL, scores = NULL, name="ROC"){
   .calcAUC <- function(TPR = NULL, FPR = NULL){
     # http://blog.revolutionanalytics.com/2016/11/calculating-auc.html

--- a/R/MarkerFeatures.R
+++ b/R/MarkerFeatures.R
@@ -746,11 +746,10 @@ getMarkerFeatures <- function(
         groupit <- match(groups[idB][knnit],names(nx))
         selectUnique <- FALSE
         selectit <- 0
-        oit <- order(groupit)
         
         while(!selectUnique){
           selectit <- selectit + 1
-          itx <- which(oit==selectit)
+          itx <- selectit
           cellx <- knnit[itx]
           groupitx <- groupit[itx]
           if(is.infinite(nx[groupitx])){


### PR DESCRIPTION
While running a differential analysis with getMarkerFeatures, I noticed that the order in which I specify samples in useGroups significantly affects results. For example, if I were to run it with useGroups = c(“group1”, “group2”) and then get markers with cutOff of FDR <= 0.05 and Log2FC >= 1, I would get 300 peaks compared to 900 peaks with exactly same run but different order of useGroups = c(“group2”, “group1”), while keeping the background consistent with "group0". I debugged the code and figured out that the reason for that is random sampling of cells in use groups in this line: 

https://github.com/GreenleafLab/ArchR/blob/f162072dfb38e62d71431506db124a7a0e09b6aa/R/MarkerFeatures.R#L675

It makes sense that the order of groups affects it, but I was wondering whether it’s the best option from a biological perspective. After discussing with my colleagues, we think that results should not be dependent on the order of provided useGroups due to the use of the sample function. Additionally, random sampling does not guarantee the matching of closest cells from background and use groups. To address this, we propose to select with the k nearest neighboring cell from background and use group instead of random sampling. I have implemented this option into your MarkerFeatures function and it’s available by setting the “closest” parameter to TRUE. I would love to get your opinion on this issue and whether you agree that this might improve the matching of cells from background and use groups.

A few words to my implementation:
-	I added a helper function to HiddenUtils, that considers distances from knn and sorts all cell-pairs between foreground and background by those distances.
-	This list is then looped through in the main function, that adds the cell pair to the analysis if both the cells haven’t been added yet.
-	The upper boarder to the number of cells for differential analysis depends on the background number. If there is one background (pairwise comparison), maximum possible number of cells is considered. Though it could easily be changed to the minTotal, if you deem it a better approach. In case of background with multiple groups, I adapted your method with background probabilities and maximum number of cells allowed for each background group. The difference between your method and mine is that it again considers the closest cells and does not rely on random sampling. 

With that last point in mind, I want to come to the second part of my issue.
 
I noticed that the behavior in the algorithm is different depending on the background groups number. 

IF there is only one background group, then always the first AND THEREFORE closest cell IN KNNX is chosen as background cell for the use group cell (if it’s taken then the second, if this one is also taken, then third and so on). That makes perfect sense to me. Because the closest cell is what desired here.

HOWEVER, IF the background consists of more than one group, NOT THE CLOSEST CELL IS SELECTED, but the cell, which index is derived from “oit”. “oit” variable has ordered groups. So when line: 

https://github.com/GreenleafLab/ArchR/blob/f162072dfb38e62d71431506db124a7a0e09b6aa/R/MarkerFeatures.R#L703

asks which index has the cell which is equal to counter (for example 1), it gets some number, that could be at any position depending on what was the group of the cell at that counter in knn. And with that the background cell is then assigned not to the first knn cell (even if it hasn’t been used yet), but to that arbitrary cell. Which can even be pretty far from the closest cell. At first, I thought it was meant to keep the proportions of background in check, but actually “nx” variable does it. Since “oit” is not used anywhere else, I can not figure the function of this variable. I think that the fix for this would be simply to set the “itx” to “selectitx” and loop through the candidate background cells from closest to furthest. 

However, if there is some specific function for this variable, that I missed, I’d be very happy if you could let me know. 
For now, this fix is a separate commit, that could be reversed.

Thank you and best regards,
Anastasiya 