### PR TITLE
add name to peakSet / PeakMatrix

### DIFF
--- a/R/ProjectMethods.R
+++ b/R/ProjectMethods.R
@@ -388,6 +388,9 @@ addPeakSet <- function(
       x
     }) %>% Reduce("c", .) %>% sortSeqlevels %>% sort
 
+    #Name each peak
+    peakSet$name <- paste0(seqnames(ps),"_peak",ps$idx)
+    
     #Get NucleoTide Content
     peakSet <- tryCatch({
       .requirePackage("Biostrings",source="bioc")


### PR DESCRIPTION
Originally, peak sets do not have a `name` column. This means that when `getFeatures()` is called, it returns `NULL` because no `name` column is present. This makes it impossible to use `plotEmbedding()` or `addModuleScores()` with peaks. To address this, I've added a line that automatically names peaks as seqname_peakIndex such as "chr1_peak1"
addressing https://github.com/GreenleafLab/ArchR/discussions/1421 and https://github.com/GreenleafLab/ArchR/issues/308#issuecomment-792338095