### PR TITLE
Dev guides

### DIFF
--- a/R/ArchRBrowser.R
+++ b/R/ArchRBrowser.R
@@ -1044,7 +1044,7 @@ plotBrowserTrack <- function(
             margin = margin(0,0.35,0,0.35, "cm")),
             strip.text.y = element_text(angle = 0),
           strip.background = element_rect(color="black")) +
-    guides(fill = FALSE, colour = FALSE) + ggtitle(title)
+    guides(fill = "none", colour = "none") + ggtitle(title)
 
   p
 
@@ -1346,7 +1346,7 @@ plotBrowserTrack <- function(
       theme(axis.title.x=element_blank(), axis.text.x=element_blank(),axis.ticks.x=element_blank()) +
       theme(axis.title.y=element_blank(), axis.text.y=element_blank(),axis.ticks.y=element_blank()) +
       theme(legend.text = element_text(size = baseSize), strip.text.y = element_text(size = facetbaseSize, angle = 0)) +
-      guides(fill = guide_legend(override.aes = list(colour = NA, shape = "c", size=3)), color = FALSE) + 
+      guides(fill = guide_legend(override.aes = list(colour = NA, shape = "c", size=3)), color = "none") + 
       theme(legend.position="bottom") +
       theme(legend.title=element_text(size=5), legend.text=element_text(size=7),
         legend.key.size = unit(0.75,"line"), legend.background = element_rect(color =NA), strip.background = element_blank())
@@ -1475,7 +1475,7 @@ plotBrowserTrack <- function(
       scale_color_manual(values = pal) +
       theme(legend.text = element_text(size = baseSize)) + 
       theme_ArchR(baseSize = baseSize, baseLineSize = borderWidth, baseRectSize = borderWidth) +
-      guides(color = FALSE, fill = FALSE) + theme(strip.text.y = element_text(size = facetbaseSize, angle = 0), strip.background = element_blank())
+      guides(color = "none", fill = "none") + theme(strip.text.y = element_text(size = facetbaseSize, angle = 0), strip.background = element_blank())
 
   }else{
 
@@ -1795,7 +1795,7 @@ plotBrowserTrack <- function(
               margin = margin(0,0.35,0,0.35, "cm")),
               strip.text.y = element_text(angle = 0),
             strip.background = element_rect(color="black")) +
-      guides(fill = FALSE, colour = FALSE) + ggtitle(title)
+      guides(fill = "none", colour = "none") + ggtitle(title)
 
     p
 
@@ -1884,7 +1884,7 @@ plotBrowserTrack <- function(
       pal = pal
     ) + 
     facet_wrap(x~., ncol=1,scales="free_y",strip.position="right") +
-    guides(fill = FALSE, colour = FALSE) +
+    guides(fill = "none", colour = "none") +
     theme_ArchR(baseSize = baseSize,
               baseRectSize = borderWidth,
               baseLineSize = tickWidth,

--- a/R/DoubletsScores.R
+++ b/R/DoubletsScores.R
@@ -378,7 +378,7 @@ addDoubletScores <- function(
         scale_colour_gradientn(colors = pal) + 
         xlab("UMAP Dimension 1") + ylab("UMAP Dimension 2") +
         labs(color = "Simulated Doublet Density") +
-        guides(fill = FALSE) + theme_ArchR(baseSize = 10) +
+        guides(fill = "none") + theme_ArchR(baseSize = 10) +
         theme(axis.text.x = element_blank(), axis.ticks.x = element_blank(), 
               axis.text.y = element_blank(), axis.ticks.y = element_blank()) +
         coord_equal(ratio = diff(xlim)/diff(ylim), xlim = xlim, ylim = ylim, expand = FALSE) +
@@ -395,7 +395,7 @@ addDoubletScores <- function(
     #     geom_point(data = dfDoub, aes(x=x,y=y,colour=color), size = 0.5) + 
     #       scale_colour_gradientn(colors = pal) + 
     #       xlab("UMAP Dimension 1") + ylab("UMAP Dimension 2") +
-    #       guides(fill = FALSE) + theme_ArchR(baseSize = 10) +
+    #       guides(fill = "none") + theme_ArchR(baseSize = 10) +
     #       labs(color = "Simulated Doublet Density") +
     #       theme(axis.text.x = element_blank(), axis.ticks.x = element_blank(), 
     #             axis.text.y = element_blank(), axis.ticks.y = element_blank()) +
@@ -413,7 +413,7 @@ addDoubletScores <- function(
     #       scale_colour_gradientn(colors = pal) + 
     #       xlab("UMAP Dimension 1") + ylab("UMAP Dimension 2") +
     #       labs(color = "Simulated Doublet Density") +
-    #       guides(fill = FALSE) + theme_ArchR(baseSize = 10) +
+    #       guides(fill = "none") + theme_ArchR(baseSize = 10) +
     #       theme(axis.text.x = element_blank(), axis.ticks.x = element_blank(), 
     #             axis.text.y = element_blank(), axis.ticks.y = element_blank()) +
     #       coord_equal(ratio = diff(xlim)/diff(ylim), xlim = xlim, ylim = ylim, expand = FALSE) +

--- a/R/Footprinting.R
+++ b/R/Footprinting.R
@@ -578,8 +578,8 @@ plotFootprints <- function(
         ylim = c(quantile(plotFootDF$mean, 0.0001), 1.15*quantile(smoothFoot, 0.999)), 
         xlim = c(min(plotFootDF$x),max(plotFootDF$x))
       ) + theme_ArchR(baseSize = baseSize) + ggtitle(name) +
-      guides(fill = FALSE) + 
-      guides(color = FALSE) + ylab(paste0(title,"Normalized Insertions"))
+      guides(fill = "none") + 
+      guides(color = "none") + ylab(paste0(title,"Normalized Insertions"))
       #removed ggrepel due to incompatibility with coord_cartesian - see https://github.com/GreenleafLab/ArchR/issues/493#issuecomment-870012873
       #ggrepel::geom_label_repel(data = plotMax, aes(label = group), size = 3, xlim = c(75, NA))
 


### PR DESCRIPTION
get rid of warnings from ggPlot2 about. This is avoided by using ` = "none"` instead of `= FALSE`

> `guides(<scale> = FALSE)` is deprecated. Please use `guides(<scale> = "none")` instead. 