### PR TITLE
save macs2 fold enrichment signal value in summits

### DIFF
--- a/R/ReproduciblePeakSet.R
+++ b/R/ReproduciblePeakSet.R
@@ -788,8 +788,8 @@ addReproduciblePeakSet <- function(
 	run <- system2(pathToMacs2, cmd, wait=TRUE, stdout=NULL, stderr=NULL)
 
 	#Read Summits!
-	out <- data.table::fread(summitsFile, select = c(1,2,3,5))
-	out <- GRanges(out$V1, IRanges(out$V2 + 1, out$V3), score = out$V5)
+	out <- data.table::fread(summitsFile, select = c(1,2,3,5,7))
+	out <- GRanges(out$V1, IRanges(out$V2 + 1, out$V3), score = out$V5, signalValue = out$V7)
 
 	#Remove Files
 	r2 <- suppressWarnings(file.remove(summitsFile, narrowPeaksFile, xlsFile))


### PR DESCRIPTION
Currently, the narrowPeak signal value at the summit isn't saved, add this to the replicate summits `.rds` file for downstream uses.