### PR TITLE
fix bug in blacklist

### DIFF
--- a/R/MatrixTiles.R
+++ b/R/MatrixTiles.R
@@ -258,8 +258,11 @@ addTileMatrix <- function(
         if(length(blacklist) > 0){
           blacklistz <- blacklist[[chr]]
           if(length(blacklistz) > 0){
-            tile2 <- floor(tileSize/2)
-            blacklistIdx <- unique(trunc(start(unlist(GenomicRanges::slidingWindows(blacklistz,tile2,tile2)))/tileSize) + 1)
+            # Convert blacklistz into "tile" coordinates (where each base represents a tile)
+            start(blacklistz) <- (start(blacklistz) %/% tileSize) + 1
+            end(blacklistz) <- (end(blacklistz) %/% tileSize) + 1
+            # Compute list of tiles within each blacklist region
+            blacklistIdx <- unlist(start(GenomicRanges::slidingWindows(blacklistz, 1, 1)))
             blacklistIdx <- sort(blacklistIdx)
             idxToZero <- which((mat@i + 1) %bcin% blacklistIdx)
             if(length(idxToZero) > 0){


### PR DESCRIPTION
blacklist overlap did not appropriately account for tiles overlapping blacklist region ends. addressing https://github.com/GreenleafLab/ArchR/issues/1741