### PR TITLE
Dev suppress warnings

### DIFF
--- a/R/Embedding.R
+++ b/R/Embedding.R
@@ -261,7 +261,12 @@ addUMAP <- function(
   eval(parse(text=strUWOT))
 
   tryCatch({
-    uwot::save_uwot(model = model, file = file, verbose = TRUE)
+    #the below call to save_uwot involves a call to utils::tar() within the uwot code. For unix systems,
+    #if the user has a user ID greater than a specific integer, it will throw an annoying warning that 
+    #otherwise cannot be controlled without supressing all warnings. Rather than do that, this helper
+    #function only suppresses warnings that contain the word "nobody". The actual warning message is:
+    #"invalid uid value replaced by that for user 'nobody'"
+    .suppressSpecificWarnings(.expr = uwot::save_uwot(model = model, file = file, verbose = TRUE), .f = "nobody")
   }, error = function(e){
     .saveUWOT_Deprecated(model = model, file = file) #backwards to previous version
   })

--- a/R/HelperUtils.R
+++ b/R/HelperUtils.R
@@ -198,7 +198,33 @@ mapLabels <- function(labels = NULL, newLabels = NULL, oldLabels = names(newLabe
 
 }
 
-
+#' This function allows you to suppress specific warnings and was originally
+#' created by Antoine Fabri ("Moody_Mudskipper"): see https://stackoverflow.com/a/55182432/697473
+#' Sometimes R throws warning messages that we don't want to see. The base
+#' \code{suppressWarnings()} function permits one to suppress warnings, but 
+#' it is tricky to selectively suppress only certain warnings on the basis 
+#' of a regular expression or another condition. This function allows one 
+#' to do that.
+#'
+#' @param .expr Expression to be evaluated. 
+#' @param .f String or function. If a string (possibly representing a 
+#'   regular expression), any warning message generated when \code{.expr} is 
+#'   evaluated will be suppressed if \code{grepl{}} finds that the string
+#'   matches the warning message.\cr
+#'     \indent If a function, the warning message will be passed to the 
+#'   function, and the function must return \code{TRUE} or \code{FALSE}. See
+#'   the examples for details.
+.suppressSpecificWarnings <- function(.expr, .f, ...) {
+  eval.parent(
+    substitute(
+      withCallingHandlers( .expr, warning = function (w) {
+        cm   <- conditionMessage(w)
+        cond <- if (is.character(.f)) grepl(.f, cm) else rlang::as_function(.f)(cm, ...)
+        if (cond) invokeRestart("muffleWarning")   
+      })
+    )
+  )
+}
 
 
 


### PR DESCRIPTION
added a helper function to suppress specific warnings based on character string matching with grep to the warning message itself. This is currently only used to suppress an annoying warning from `utils::tar()` (called in `save_uwot()` but could be used in other cases where specific warnings can be ignored safely.