### PR TITLE
set bcPass as a character vector

### DIFF
--- a/R/CreateArrow.R
+++ b/R/CreateArrow.R
@@ -1968,7 +1968,7 @@ createArrowFiles <- function(
           #Order RG RLE based on bcPass
           fragments <- fragments[BiocGenerics::which(paste0(mcols(fragments)$RG) %bcin% bcPass)]
           if(length(fragments) > 0){
-            fragments <- fragments[order(S4Vectors::match(paste0(mcols(fragments)$RG), bcPass))]
+            fragments <- fragments[order(S4Vectors::match(paste0(mcols(fragments)$RG), as.character(bcPass)))]
           }
           
           #Check if Fragments are greater than minFragSize and smaller than maxFragSize
@@ -2062,7 +2062,7 @@ createArrowFiles <- function(
           #Order RG RLE based on bcPass
           fragments <- fragments[BiocGenerics::which(paste0(mcols(fragments)$RG) %bcin% bcPass)]
           if(length(fragments) > 0){
-            fragments <- fragments[order(S4Vectors::match(paste0(mcols(fragments)$RG), bcPass))]
+            fragments <- fragments[order(S4Vectors::match(paste0(mcols(fragments)$RG), as.character(bcPass)))]
           }
 
           #Check if Fragments are greater than minFragSize and smaller than maxFragSize


### PR DESCRIPTION
I've sporadically received a cryptic error from createArrowFiles() that seems to boil down to an S4Vectors issue with the match() function and the BStringSet bcPass object (shown below). This should be fixed by this commit but its a sporadic error and hard to test.

```
<simpleError in h(simpleError(msg, call)): error in evaluating the argument 'i' in selecting a method for function '[': error in evaluating the argument 'x' in selecting a method for function 'which': no met
hod found for function 'match' and signature XRawList, XRawList>
```