### PR TITLE
Remove no space requirement for paths in AllClasses.R

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -107,13 +107,7 @@ ArchRProject <- function(
   .validInput(input = showLogo, name = "showLogo", valid = "boolean")
   .validInput(input = threads, name = "threads", valid = c("integer"))
 
-  if(grepl(" ", outputDirectory)){
-    stop("outputDirectory cannot have a space in the path! Path : ", outputDirectory)
-  }
   dir.create(outputDirectory,showWarnings=FALSE)
-  if(grepl(" ", normalizePath(outputDirectory))){
-    stop("outputDirectory cannot have a space in the full path! Full path : ", normalizePath(outputDirectory))
-  }
   sampleDirectory <- file.path(normalizePath(outputDirectory), "ArrowFiles")
   dir.create(sampleDirectory,showWarnings=FALSE)
 
@@ -497,10 +491,6 @@ saveArchRProject <- function(
   .validInput(input = outputDirectory, name = "outputDirectory", valid = "character")
   .validInput(input = overwrite, name = "overwrite", valid = "boolean")
   .validInput(input = load, name = "load", valid = "boolean")
-
-  if(grepl(" ", outputDirectory)){
-    stop("outputDirectory cannot have a space in the path! Path : ", outputDirectory)
-  }
 
   dir.create(outputDirectory, showWarnings=FALSE)
   outputDirectory <- normalizePath(outputDirectory)


### PR DESCRIPTION
Quick fix for output directories requiring no spaces. I understand it is not the best practice to have spaces in path names. However, I don't believe this should be a requirement in ArchR and instead should be left up to the user as (I believe) no errors are created without this requirement. This change would be in line with similar to functions like 'readRDS' where only valid characters are checked which these functions already do.