### PR TITLE
change use.names to False in addPeakAnnotations

### DIFF
--- a/R/AnnotationPeaks.R
+++ b/R/AnnotationPeaks.R
@@ -196,7 +196,7 @@ addPeakAnnotations <- function(
   if(is.null(peakSet)){
     .logStop("peakSet is NULL. You need a peakset to run addMotifAnnotations! See addReproduciblePeakSet!", logFile = logFile)
   }
-  allPositions <- unlist(regionPositions, use.names=TRUE)
+  allPositions <- unlist(regionPositions, use.names=FALSE)
 
   .logDiffTime("Creating Peak Overlap Matrix", t1 = tstart, verbose = TRUE, logFile = logFile)
 


### PR DESCRIPTION
Hello,

When I try to add my custom region annotation using `addPeakAnnotations` it returns an error. I went through the code and realized `use.names=TRUE` [here](https://github.com/GreenleafLab/ArchR/blob/c61b0645d1482f80dcc24e25fbd915128c1b2500/R/AnnotationPeaks.R#L199) causing the issue, when `FALSE` it works. 

I will add the log-files