### PR TITLE
add version argument for writing gene expression to hdf5

### DIFF
--- a/R/MatrixGeneExpression.R
+++ b/R/MatrixGeneExpression.R
@@ -34,7 +34,8 @@ addGeneExpressionMatrix <- function(
   parallelParam = NULL,
   strictMatch = FALSE,
   force = TRUE,
-  logFile = createLogFile("addGeneExpressionMatrix")
+  logFile = createLogFile("addGeneExpressionMatrix"),
+  version = 2
   ){
 
   .validInput(input = input, name = "input", valid = c("ArchRProj", "character"))
@@ -201,7 +202,8 @@ addGeneExpressionMatrix <- function(
   subThreads = 1,
   force = FALSE,
   verbose = TRUE,
-  logFile = NULL
+  logFile = NULL,
+  version = 2
   ){
 
   ArrowFile <- ArrowFiles[i]
@@ -286,7 +288,8 @@ addGeneExpressionMatrix <- function(
         binarize = FALSE,
         addColSums = TRUE,
         addRowSums = TRUE,
-        addRowVarsLog2 = TRUE #add for integration analyses
+        addRowVarsLog2 = TRUE, #add for integration analyses
+        version = version
       )
       gc()
 


### PR DESCRIPTION
I noticed that the current package has introduced `version` argument, along with other new arguments in the `addMatToArrow` function,


https://github.com/GreenleafLab/ArchR/blob/65968a4068253783fe6b0918efcbf7d216a49ee7/R/ArrowWrite.R#L105-L126

but the higher-level function `addGeneExpressionMatrix` does not support passing those new arguments.

This pull request aims to provide the option to use the hdf5 style of the old version (version = 1).