### PR TITLE
remove seurat/harmony warnings

### DIFF
--- a/R/Clustering.R
+++ b/R/Clustering.R
@@ -435,7 +435,7 @@ addClusters <- function(
 
   clustParams <- tryCatch({
 
-    obj <- Seurat::CreateSeuratObject(tmp, project='scATAC', min.cells=0, min.features=0)
+    obj <- suppressWarnings(Seurat::CreateSeuratObject(tmp, project='scATAC', min.cells=0, min.features=0))
     obj[['pca']] <- Seurat::CreateDimReducObject(embeddings=mat, key='PC_', assay='RNA')
     clustParams$object <- obj
     clustParams$reduction <- "pca"
@@ -469,7 +469,7 @@ addClusters <- function(
         colnames(tmp) <- rownames(mat)
         rownames(tmp) <- paste0("t",seq_len(nrow(tmp)))
 
-        obj <- Seurat::CreateSeuratObject(tmp, project='scATAC', min.cells=0, min.features=0)
+        obj <- suppressWarnings(Seurat::CreateSeuratObject(tmp, project='scATAC', min.cells=0, min.features=0))
         obj[['pca']] <- Seurat::CreateDimReducObject(embeddings=mat, key='PC_', assay='RNA')
         clustParams$object <- obj
         clustParams$reduction <- "pca"

--- a/R/Harmony.R
+++ b/R/Harmony.R
@@ -80,7 +80,7 @@ addHarmony <- function(
   harmonyParams$plot_convergence <- FALSE
 
   #Call Harmony
-  harmonyMat <- do.call(HarmonyMatrix, harmonyParams)
+  harmonyMat <- suppressWarnings(do.call(HarmonyMatrix, harmonyParams))
   harmonyParams$data_mat <- NULL
   ArchRProj@reducedDims[[name]] <- SimpleList(
     matDR = harmonyMat, 
@@ -89,7 +89,6 @@ addHarmony <- function(
     scaleDims = NA, #Do not scale dims after
     corToDepth = NA
   )
-
   ArchRProj
 
 }

--- a/R/RNAIntegration.R
+++ b/R/RNAIntegration.R
@@ -220,7 +220,7 @@ addGeneIntegrationMatrix <- function(
 
   #Set up RNA
   if(inherits(seRNA, "SummarizedExperiment")){
-    seuratRNA <- CreateSeuratObject(counts = assay(seRNA))
+    seuratRNA <- suppressWarnings(CreateSeuratObject(counts = assay(seRNA)))
     if(groupRNA %ni% colnames(colData(seRNA))){
       .logMessage("groupRNA not in colData of seRNA", logFile = logFile)
       stop("groupRNA not in colData of seRNA")
@@ -475,7 +475,7 @@ addGeneIntegrationMatrix <- function(
 
     #Log-Normalize 
     mat <- log(mat + 1) #use natural log
-    seuratATAC <- Seurat::CreateSeuratObject(counts = mat[head(seq_len(nrow(mat)), 5), , drop = FALSE])
+    seuratATAC <- supressWarninggs(Seurat::CreateSeuratObject(counts = as.matrix(mat[head(seq_len(nrow(mat)), 5), , drop = FALSE])))
     seuratATAC[["GeneScore"]] <- Seurat::CreateAssayObject(counts = mat)
     
     #Clean Memory


### PR DESCRIPTION
## Details
Seurat v5 now gives warnings when converting matrices from different types (ie `matrix` to `dgCmatrix`, `dgEMatrix` to `dgCMatrix`).  To keep consistent within our package, we do not change matrix types within ArchR itself.  Adding in supressions does not affect the underlying code, but does prevent unwanted warning messages from popping up to the end user.

On the other hand, HarmonyMatrix has been deprecated, and does pose a future issue.  As the replacement API, `RunHarmony`  seems to be specific to Seurat/SCE objects, we table this for now.  Additionally, the params being passed in are completely different and will require a broad rewrite. These changes are tabled until a later time.

## Tests
Ran on all unit tests, warnings reduced from 13 to 0.