### PR TITLE
fix issues with creating Seuratv5 obj

### DIFF
--- a/R/RNAIntegration.R
+++ b/R/RNAIntegration.R
@@ -472,7 +472,10 @@ addGeneIntegrationMatrix <- function(
       o <- suppressWarnings(file.remove(unlist(getImputeWeights(subProj)[[1]]))) #Clean Up Space
       .logThis(mat, paste0("GeneScoreMat-Block-Impute-",i), logFile=logFile)
     }
-
+    # Seurat v5 requires character type row/colnames
+    # sparse matrices occasionally convert names to array type, so convert back to create seurat obj
+    rownames(mat) <- as.character(rownames(mat))
+    colnames(mat) <- as.character(colnames(mat))
     #Log-Normalize 
     mat <- log(mat + 1) #use natural log
     seuratATAC <- Seurat::CreateSeuratObject(counts = mat[head(seq_len(nrow(mat)), 5), , drop = FALSE])


### PR DESCRIPTION
## Details

Seurat v5 had a regression in terms of the flexibility of objects that can be imported in.  Specifically, colnames are rownames are constrained to only be type `character`, with no smart conversions on their end as of now.  As our dgEMatrix had type `array` for colnames and rownames, a simple switch fixes this errant behaviour.  An associated error message people received was (`Error in slot(object = object, name = "features")[[layer]] <- features: more elements supplied than there are to replace`)

Fixes #2212, #2136, #2069, #2052, #1999, #2091, #2040

## Tests

- Ran with all unit tests on R `4.1`, `4.4`.  Regressions with creating Seurat objects are no longer failing.